### PR TITLE
`guildAdmin` client

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,30 +23,31 @@ Guild.xyz is the membership layer protocol for web3 communities, making communit
 
 ## Migration Guide to V2
 
-⚠️ `1.x.x versions` of the SDK are ***deprecated***, these versions won't work after ***2024-01-31***. Please migrate to the latest version. You can find the migration guide [HERE](https://github.com/guildxyz/guild-sdk/blob/main/v2-migration-guide.md#guild-sdk-v2-migration-guide).
+⚠️ `1.x.x versions` of the SDK are **_deprecated_**, these versions won't work after **_2024-01-31_**. Please migrate to the latest version. You can find the migration guide [HERE](https://github.com/guildxyz/guild-sdk/blob/main/v2-migration-guide.md#guild-sdk-v2-migration-guide).
 
 ## Contents
 
 - [Installation](#installation)
 - [Importing the package and creating a Guild client](#importing-the-package-and-creating-a-guild-client)
 - [SignerFunctions and Authentication](#signerfunctions-and-authentication)
-  + [ethers.js](#creating-a-signer-from-an-ethers-wallet)
-  + [web3-react](#creating-a-custom-signer-for-usage-with-web3-react)
-  + [wagmi](#creating-a-custom-signer-for-usage-with-wagmi)
-  + [EIP-1271](#support-for-eip-1271-smart-contract-wallets)
+  - [ethers.js](#creating-a-signer-from-an-ethers-wallet)
+  - [web3-react](#creating-a-custom-signer-for-usage-with-web3-react)
+  - [wagmi](#creating-a-custom-signer-for-usage-with-wagmi)
+  - [EIP-1271](#support-for-eip-1271-smart-contract-wallets)
 - [Clients](#clients)
-  + [Guild client](#guild-client)
-  + [Guild reward client](#guild-reward-client)
-  + [Role client](#role-client)
-  + [Requirement client](#requirement-client)
-  + [Role reward client](#role-reward-client)
-  + [User client](#user-client)
-  + [User address client](#user-address-client)
-  + [User platform client](#user-platform-client)
+  - [Guild client](#guild-client)
+  - [Guild admin client](#guild-admin-client)
+  - [Guild reward client](#guild-reward-client)
+  - [Role client](#role-client)
+  - [Requirement client](#requirement-client)
+  - [Role reward client](#role-reward-client)
+  - [User client](#user-client)
+  - [User address client](#user-address-client)
+  - [User platform client](#user-platform-client)
 - [Modular / multi-platform architecture](#modular--multi-platform-architecture)
 - [Examples](#examples)
-  + [Example flow from Create Guild to Join](#example-flow-from-create-guild-to-join)
-  + [Multiple telegram groups guild](#multiple-telegram-groups-guild)
+  - [Example flow from Create Guild to Join](#example-flow-from-create-guild-to-join)
+  - [Multiple telegram groups guild](#multiple-telegram-groups-guild)
 
 ### Installation
 
@@ -158,6 +159,20 @@ await client.update(guildId, { description: "Edited" }, signerFunction);
 
 // Delete a guild
 await client.delete(guildId, signerFunction);
+```
+
+#### `Guild admin client`
+
+```ts
+const {
+  guild: { admin: adminClient },
+} = guildClient;
+
+// Get all admins of a guild
+const admins = await adminClient.getAll(guildIdOrUrlName);
+
+// Get a specific admin of a guild
+const admin = await adminClient.get(guildIdOrUrlName, userIdOfAdmin);
 ```
 
 #### `Guild reward client`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guildxyz/sdk",
-  "version": "2.0.0-rc.8",
+  "version": "2.1.0",
   "description": "SDK for Guild.xyz Public API ",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/clients/guild.ts
+++ b/src/clients/guild.ts
@@ -5,6 +5,7 @@ import {
   Schemas,
 } from "@guildxyz/types";
 import { SignerFunction, callGuildAPI } from "../utils";
+import guildAdmin from "./guildAdmin";
 import guildReward from "./guildReward";
 import role from "./role";
 
@@ -12,6 +13,8 @@ const guild = {
   role,
 
   reward: guildReward,
+
+  admin: guildAdmin,
 
   get: (guildIdOrUrlName: number | string) =>
     callGuildAPI<Guild>({ url: `/guilds/${guildIdOrUrlName}`, method: "GET" }),

--- a/src/clients/guildAdmin.ts
+++ b/src/clients/guildAdmin.ts
@@ -1,0 +1,18 @@
+import { GuildAdmin } from "@guildxyz/types";
+import { callGuildAPI } from "../utils";
+
+const guildAdmin = {
+  get: (guildIdOrUrlName: string | number, userId: number) =>
+    callGuildAPI<GuildAdmin>({
+      url: `/guilds/${guildIdOrUrlName}/admins/${userId}`,
+      method: "GET",
+    }),
+
+  getAll: (guildIdOrUrlName: string | number) =>
+    callGuildAPI<GuildAdmin[]>({
+      url: `/guilds/${guildIdOrUrlName}/admins`,
+      method: "GET",
+    }),
+};
+
+export default guildAdmin;

--- a/src/clients/guildAdmin.ts
+++ b/src/clients/guildAdmin.ts
@@ -1,5 +1,5 @@
-import { GuildAdmin } from "@guildxyz/types";
-import { callGuildAPI } from "../utils";
+import { GuildAdmin, Schemas } from "@guildxyz/types";
+import { SignerFunction, callGuildAPI } from "../utils";
 
 const guildAdmin = {
   get: (guildIdOrUrlName: string | number, userId: number) =>
@@ -12,6 +12,48 @@ const guildAdmin = {
     callGuildAPI<GuildAdmin[]>({
       url: `/guilds/${guildIdOrUrlName}/admins`,
       method: "GET",
+    }),
+
+  create: (
+    guildIdOrUrlName: string | number,
+    guildAdminCreationParams: Schemas["GuildAdminCreationPayload"],
+    signer: SignerFunction
+  ) =>
+    callGuildAPI<GuildAdmin>({
+      url: `/guilds/${guildIdOrUrlName}/admins`,
+      method: "POST",
+      body: {
+        schema: "GuildAdminCreationPayloadSchema",
+        data: guildAdminCreationParams,
+      },
+      signer,
+    }),
+
+  update: (
+    guildIdOrUrlName: string | number,
+    adminUserId: number,
+    guildAdminUpdateParams: Schemas["GuildAdminUpdatePayload"],
+    signer: SignerFunction
+  ) =>
+    callGuildAPI<GuildAdmin>({
+      url: `/guilds/${guildIdOrUrlName}/admins/${adminUserId}`,
+      method: "PUT",
+      body: {
+        schema: "GuildAdminUpdatePayloadSchema",
+        data: guildAdminUpdateParams,
+      },
+      signer,
+    }),
+
+  delete: (
+    guildIdOrUrlName: string | number,
+    adminUserId: number,
+    signer: SignerFunction
+  ) =>
+    callGuildAPI<void>({
+      url: `/guilds/${guildIdOrUrlName}/admins/${adminUserId}`,
+      method: "DELETE",
+      signer,
     }),
 };
 

--- a/tests/clients/guildAdmin.test.ts
+++ b/tests/clients/guildAdmin.test.ts
@@ -1,7 +1,14 @@
+import { Wallet } from "ethers";
 import { describe, expect, it } from "vitest";
-import { createGuildClient } from "../../src";
+import { GuildAPICallFailed, createGuildClient, createSigner } from "../../src";
 
 const client = createGuildClient("vitest");
+
+const TEST_WALLET_SIGNER = createSigner.fromEthersWallet(
+  new Wallet(process.env.PRIVATE_KEY!)
+);
+const GUILD_ID = "sdk-test-guild-62011a";
+const adminAddress = Wallet.createRandom().address.toLowerCase();
 
 describe("Guild admins", () => {
   it("get all", async () => {
@@ -12,5 +19,45 @@ describe("Guild admins", () => {
   it("get", async () => {
     const admin = await client.guild.admin.get(1985, 45);
     expect(admin).toMatchObject({ userId: 45 });
+  });
+
+  let adminUserId: number;
+
+  it("create", async () => {
+    const newAdmin = await client.guild.admin.create(
+      GUILD_ID,
+      {
+        address: adminAddress,
+        isOwner: false,
+      },
+      TEST_WALLET_SIGNER
+    );
+
+    adminUserId = newAdmin.userId;
+
+    expect(newAdmin).toMatchObject({ isOwner: false });
+  });
+
+  it("get created admin", async () => {
+    const admin = await client.guild.admin.get(GUILD_ID, adminUserId);
+    expect(admin).toMatchObject({ userId: adminUserId, isOwner: false });
+  });
+
+  it("delete", async () => {
+    await client.guild.admin.delete(
+      GUILD_ID,
+      adminUserId,
+
+      TEST_WALLET_SIGNER
+    );
+  });
+
+  it("can't get created admin", async () => {
+    try {
+      await client.guild.admin.get(GUILD_ID, adminUserId);
+    } catch (error) {
+      expect(error).toBeInstanceOf(GuildAPICallFailed);
+      expect(error.statusCode).toEqual(404);
+    }
   });
 });

--- a/tests/clients/guildAdmin.test.ts
+++ b/tests/clients/guildAdmin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createGuildClient } from "../../src";
+
+const client = createGuildClient("vitest");
+
+describe("Guild admins", () => {
+  it("get all", async () => {
+    const admins = await client.guild.admin.getAll(1985);
+    expect(admins.length).toBeGreaterThan(0);
+  });
+
+  it("get", async () => {
+    const admin = await client.guild.admin.get(1985, 45);
+    expect(admin).toMatchObject({ userId: 45 });
+  });
+});

--- a/v2-migration-guide.md
+++ b/v2-migration-guide.md
@@ -130,13 +130,18 @@ This method doesn't exist anymore
 
 #### `get`
 
-Use `guild.get`. The response won't include roles, nor rewards. Those can be fetched with `guild.role.getAll` and `guild.reward.getAll`
+Use `guild.get`. The response won't include roles, rewards, nor admins. Those can be fetched with `guild.role.getAll`, `guild.reward.getAll`, and `guild.admin.getAll`
 
 ```ts
 import { guild } from "@guildxyz/sdk";
 
-const result = await guild.get(someGuildId);
+const guild = await guild.get(someGuildId);
+const guildPlatforms = await guild.reward.getAll(someGuildId);
+const roles = await guild.role.getAll(someGuildId);
+const admins = await guild.admin.getAll(someGuildId);
 ```
+
+> Note that the role response won't include everything either, rolePlatforms/rewards, and requirements will be missing, those can be fetched with `guild.role.reward.getAll` and `guild.role.requirement.getAll`
 
 #### `getUserAccess`
 


### PR DESCRIPTION
This PR adds a `guildAdmin` client to the `guild` client, exposing `get`, `getAll` `create`, `update`, and `delete` methods for managing guild admins