### PR TITLE
Add create-guild-profile example

### DIFF
--- a/examples/create-guild-profile/index.ts
+++ b/examples/create-guild-profile/index.ts
@@ -1,58 +1,15 @@
 /**
- * Create Guild Profile Example
+ * Create Guild Profile — BeatinDaBlock Podcast
  *
- * This example demonstrates how to create a guild profile using the Guild SDK.
- * It shows how to:
- *   - Initialize the Guild client
- *   - Create a signer from a wallet
- *   - Create a guild with a name, description, and a free-to-join role
+ * This example demonstrates how to create a guild profile for the
+ * "BeatinDaBlock" podcast using the Guild SDK.
  *
  * Usage:
  *   PRIVATE_KEY=<your-private-key> npm start
- *
- * The wallet address 0x99295ff548fe9760494a005855a46a958b02a33c is used as an
- * example — replace the PRIVATE_KEY env var with your own key when running.
  */
 
 import { createGuildClient, createSigner } from "@guildxyz/sdk";
 import { Wallet } from "ethers";
-
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
-
-const GUILD_PROFILES = [
-  {
-    name: "Web3 Builders",
-    urlName: "web3-builders",
-    description:
-      "A community for developers building on-chain applications, protocols, and tooling.",
-  },
-  {
-    name: "DeFi Explorers",
-    urlName: "defi-explorers",
-    description:
-      "Discover and discuss the latest in decentralised finance — AMMs, lending protocols, and yield strategies.",
-  },
-  {
-    name: "NFT Creators Collective",
-    urlName: "nft-creators-collective",
-    description:
-      "Artists and collectors shaping the future of digital ownership through NFTs.",
-  },
-  {
-    name: "DAO Governance Forum",
-    urlName: "dao-governance-forum",
-    description:
-      "A space for DAO contributors to collaborate on proposals, voting, and on-chain governance.",
-  },
-  {
-    name: "Crypto Security Guild",
-    urlName: "crypto-security-guild",
-    description:
-      "White-hats, auditors, and researchers dedicated to making web3 safer for everyone.",
-  },
-];
 
 // ---------------------------------------------------------------------------
 // Main
@@ -66,29 +23,24 @@ async function main() {
 
   console.log(`Using wallet: ${wallet.address}`);
 
-  const client = createGuildClient("create-guild-profile-example");
+  const client = createGuildClient("beatindablock-guild-setup");
   const signer = createSigner.fromEthersWallet(wallet, {
     msg: "Create my Guild profile",
   });
 
-  // Pick one of the brainstormed guild ideas (index can be overridden via env)
-  const profileIndex = Number(process.env.PROFILE_INDEX ?? 0);
-  const profile = GUILD_PROFILES[profileIndex % GUILD_PROFILES.length];
-
-  console.log(`\nCreating guild: "${profile.name}"`);
-  console.log(`Description   : ${profile.description}\n`);
+  console.log('\nCreating guild: "BeatinDaBlock"');
 
   const created = await client.guild.create(
     {
-      name: profile.name,
-      urlName: profile.urlName,
-      description: profile.description,
+      name: "BeatinDaBlock",
+      urlName: "beatindablock",
+      description:
+        "The official community for BeatinDaBlock — a podcast covering hip-hop culture, music production, and the intersection of beats and blockchain.",
       contacts: [],
-      // Every guild needs at least one role.  We add a free-access role so
-      // anyone can join and explore the community.
+      // Free-to-join listener role so any fan can get access right away.
       roles: [
         {
-          name: "Member",
+          name: "Listener",
           requirements: [{ type: "FREE" }],
         },
       ],

--- a/examples/create-guild-profile/index.ts
+++ b/examples/create-guild-profile/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Create Guild Profile Example
+ *
+ * This example demonstrates how to create a guild profile using the Guild SDK.
+ * It shows how to:
+ *   - Initialize the Guild client
+ *   - Create a signer from a wallet
+ *   - Create a guild with a name, description, and a free-to-join role
+ *
+ * Usage:
+ *   PRIVATE_KEY=<your-private-key> npm start
+ *
+ * The wallet address 0x99295ff548fe9760494a005855a46a958b02a33c is used as an
+ * example — replace the PRIVATE_KEY env var with your own key when running.
+ */
+
+import { createGuildClient, createSigner } from "@guildxyz/sdk";
+import { Wallet } from "ethers";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const GUILD_PROFILES = [
+  {
+    name: "Web3 Builders",
+    urlName: "web3-builders",
+    description:
+      "A community for developers building on-chain applications, protocols, and tooling.",
+  },
+  {
+    name: "DeFi Explorers",
+    urlName: "defi-explorers",
+    description:
+      "Discover and discuss the latest in decentralised finance — AMMs, lending protocols, and yield strategies.",
+  },
+  {
+    name: "NFT Creators Collective",
+    urlName: "nft-creators-collective",
+    description:
+      "Artists and collectors shaping the future of digital ownership through NFTs.",
+  },
+  {
+    name: "DAO Governance Forum",
+    urlName: "dao-governance-forum",
+    description:
+      "A space for DAO contributors to collaborate on proposals, voting, and on-chain governance.",
+  },
+  {
+    name: "Crypto Security Guild",
+    urlName: "crypto-security-guild",
+    description:
+      "White-hats, auditors, and researchers dedicated to making web3 safer for everyone.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  // Resolve the private key from the environment, or fall back to a random
+  // wallet for demonstration purposes.
+  const privateKey = process.env.PRIVATE_KEY;
+  const wallet = privateKey ? new Wallet(privateKey) : Wallet.createRandom();
+
+  console.log(`Using wallet: ${wallet.address}`);
+
+  const client = createGuildClient("create-guild-profile-example");
+  const signer = createSigner.fromEthersWallet(wallet, {
+    msg: "Create my Guild profile",
+  });
+
+  // Pick one of the brainstormed guild ideas (index can be overridden via env)
+  const profileIndex = Number(process.env.PROFILE_INDEX ?? 0);
+  const profile = GUILD_PROFILES[profileIndex % GUILD_PROFILES.length];
+
+  console.log(`\nCreating guild: "${profile.name}"`);
+  console.log(`Description   : ${profile.description}\n`);
+
+  const created = await client.guild.create(
+    {
+      name: profile.name,
+      urlName: profile.urlName,
+      description: profile.description,
+      contacts: [],
+      // Every guild needs at least one role.  We add a free-access role so
+      // anyone can join and explore the community.
+      roles: [
+        {
+          name: "Member",
+          requirements: [{ type: "FREE" }],
+        },
+      ],
+    },
+    signer
+  );
+
+  console.log("Guild created successfully!");
+  console.log(`  id      : ${created.id}`);
+  console.log(`  urlName : ${created.urlName}`);
+  console.log(`  url     : https://guild.xyz/${created.urlName}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/create-guild-profile/package.json
+++ b/examples/create-guild-profile/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "create-guild-profile",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx ts-node --esm index.ts"
+  },
+  "dependencies": {
+    "@guildxyz/sdk": "^2.6.8",
+    "ethers": "^6.7.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/examples/create-guild-profile/tsconfig.json
+++ b/examples/create-guild-profile/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
This PR adds a new example demonstrating how to create a guild profile using the Guild SDK. The example showcases the creation of a "BeatinDaBlock" podcast community with a free-to-join listener role.

## Changes
- **New example project**: `examples/create-guild-profile/`
  - `index.ts`: Main example script that demonstrates guild creation workflow
  - `package.json`: Project configuration with required dependencies (@guildxyz/sdk, ethers)
  - `tsconfig.json`: TypeScript configuration for the example

## Implementation Details
- The example accepts a `PRIVATE_KEY` environment variable for wallet authentication, with a fallback to a random wallet for demonstration
- Uses the Guild SDK's `createGuildClient` and `createSigner` utilities to authenticate and create a guild
- Creates a guild with a single "Listener" role that has no requirements (free-to-join)
- Outputs the created guild's ID, URL name, and full Guild.xyz URL upon successful creation
- Includes proper error handling and console logging for user feedback

https://claude.ai/code/session_01CUJ8tVtqjxLpWxCN3fLYQk